### PR TITLE
Add useful Bool2Int funcion

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -218,6 +218,16 @@ func Str2Bool(val string) bool {
 	panic(errors.New("could not resolve bool value:" + val))
 }
 
+// Convert bool to int, never panics
+func Bool2Int(val bool) int {
+	if val == true {
+		return 1
+	}
+	if val == false {
+		return 0
+	}
+}
+
 
 // Convert different types to byte slice using types and functions in unsafe and reflect package. 
 // It has higher performance, but notice that it may be not safe when garbage collection happens.


### PR DESCRIPTION
I have a similar function for this in my code (but it had to do with Cgo "C.int" type). I think this proposal is in line with your package. Let me know if there is something I should change.

I have attached a screenshot that shows how normal type conversions don't allow bool2int conversions out of the box.
![bool2int](https://user-images.githubusercontent.com/18239595/51957753-27f2b080-240a-11e9-96ca-5a0563108f6d.png)
